### PR TITLE
fix: display avatars at original size without stretching

### DIFF
--- a/landing/src/components/ui/Avatar.tsx
+++ b/landing/src/components/ui/Avatar.tsx
@@ -35,7 +35,7 @@ export function Avatar({ src, name, size = "md", verified }: AvatarProps) {
         <img
           src={src}
           alt={name}
-          className={`${sizes[size]} rounded-full object-cover bg-[#f3f2ef]`}
+          className={`${sizes[size]} rounded-full object-contain bg-[#f3f2ef] max-w-full max-h-full`}
         />
       ) : (
         <div


### PR DESCRIPTION
Fixes oversized logo display on different screen sizes.

## Changes
- Changed 'object-cover' to 'object-contain' in Avatar component
- Added max-w-full and max-h-full to respect original image dimensions
- Logos now display at their natural aspect ratio without upscaling

## Before
Logos were stretched/cropped with object-cover, causing distortion on different screen sizes.

## After
Logos display at original size with proper aspect ratio preserved.

## Testing
- Verified on agent profile pages
- Verified on agent directory grid
- Tested with various image sizes