### PR TITLE
Add API endpoint to delete comments

### DIFF
--- a/landing/convex/http.ts
+++ b/landing/convex/http.ts
@@ -343,6 +343,25 @@ http.route({
   }),
 });
 
+// POST /api/comments/delete - Delete a comment
+http.route({
+  path: "/api/comments/delete",
+  method: "POST",
+  handler: httpAction(async (ctx, request) => {
+    const apiKey = getApiKey(request);
+    if (!apiKey) {
+      return jsonResponse({ error: "API key required" }, 401);
+    }
+    try {
+      const body = await request.json() as { commentId: string };
+      const result = await ctx.runMutation(api.comments.deleteComment, { apiKey, commentId: body.commentId as any });
+      return jsonResponse(result, result.success ? 200 : 400);
+    } catch (error) {
+      return jsonResponse({ success: false, error: String(error) }, 400);
+    }
+  }),
+});
+
 // ============ VOTES ============
 
 // POST /api/votes/post - Toggle post upvote
@@ -710,6 +729,12 @@ http.route({
 
 http.route({
   path: "/api/comments",
+  method: "OPTIONS",
+  handler: httpAction(async () => corsResponse()),
+});
+
+http.route({
+  path: "/api/comments/delete",
   method: "OPTIONS",
   handler: httpAction(async () => corsResponse()),
 });


### PR DESCRIPTION
## Summary
This PR adds a new HTTP endpoint to allow authenticated users to delete comments via the API.

## Changes
- **POST /api/comments/delete**: New endpoint that accepts a `commentId` in the request body and deletes the associated comment
  - Requires API key authentication
  - Returns success/failure status with appropriate HTTP status codes (200 on success, 400 on failure)
  - Includes error handling for invalid requests
- **OPTIONS /api/comments/delete**: Added CORS preflight handler for the new delete endpoint

## Implementation Details
- The endpoint validates the API key before processing the deletion request
- The request body expects a JSON object with a `commentId` string field
- Delegates the actual deletion logic to the `api.comments.deleteComment` mutation
- Returns appropriate HTTP status codes: 200 for successful deletion, 400 for errors
- Includes CORS support for cross-origin requests

https://claude.ai/code/session_015QiyHfiVvw5dAgNL5Ua7b2