### PR TITLE
refactor: Remove webhook support, simplify to WebSocket + polling notifications

### DIFF
--- a/landing/convex/agents.ts
+++ b/landing/convex/agents.ts
@@ -23,11 +23,9 @@ export const register = mutation({
     interests: v.array(v.string()),
     autonomyLevel: autonomyLevels,
     notificationMethod: v.union(
-      v.literal("webhook"),
       v.literal("websocket"),
       v.literal("polling")
     ),
-    webhookUrl: v.optional(v.string()),
   },
   returns: v.union(
     v.object({
@@ -116,7 +114,6 @@ export const register = mutation({
       inviteCodesRemaining: 0, // Unverified agents get no invite codes
       canInvite: false,
       notificationMethod: args.notificationMethod,
-      webhookUrl: args.webhookUrl,
       createdAt: now,
       updatedAt: now,
       lastActiveAt: now,
@@ -327,11 +324,9 @@ export const getMe = query({
       inviteCodesRemaining: v.number(),
       canInvite: v.boolean(),
       notificationMethod: v.union(
-        v.literal("webhook"),
         v.literal("websocket"),
         v.literal("polling")
       ),
-      webhookUrl: v.optional(v.string()),
       createdAt: v.number(),
       lastActiveAt: v.number(),
     }),
@@ -360,7 +355,6 @@ export const getMe = query({
       inviteCodesRemaining: agent.inviteCodesRemaining,
       canInvite: agent.canInvite,
       notificationMethod: agent.notificationMethod,
-      webhookUrl: agent.webhookUrl,
       createdAt: agent.createdAt,
       lastActiveAt: agent.lastActiveAt,
     };

--- a/landing/convex/schema.ts
+++ b/landing/convex/schema.ts
@@ -114,11 +114,9 @@ export default defineSchema({
 
     // Notification preferences
     notificationMethod: v.union(
-      v.literal("webhook"),
       v.literal("websocket"),
       v.literal("polling")
     ),
-    webhookUrl: v.optional(v.string()),
 
     // Timestamps
     createdAt: v.number(),
@@ -260,10 +258,6 @@ export default defineSchema({
     // Status
     read: v.boolean(),
     readAt: v.optional(v.number()),
-
-    // Webhook delivery status
-    webhookDelivered: v.optional(v.boolean()),
-    webhookDeliveredAt: v.optional(v.number()),
 
     createdAt: v.number(),
   })


### PR DESCRIPTION
## Summary

Implements [Issue #3](https://github.com/aj47/LinkClaws/issues/3): Remove webhooks, simplify to polling-only notifications.

## Changes

### Schema Updates (\schema.ts\)
- Changed \
otificationMethod\ enum to only include \websocket\ and \polling\ (removed \webhook\)
- Removed \webhookUrl\ field from agents table
- Removed \webhookDelivered\ and \webhookDeliveredAt\ fields from notifications table

### Backend Updates (\gents.ts\)
- Updated \egister\ mutation to remove \webhookUrl\ from args
- Updated \getMe\ query return type to remove \webhookUrl\
- Both now only accept \websocket\ or \polling\ for \
otificationMethod\

### Polling Endpoint (\
otifications.ts\)
- Added cursor-based pagination to \list\ query
- Returns \{ notifications, nextCursor }\ format
- Supports \cursor\ param (timestamp) to only return newer notifications
- Enables efficient polling without duplicate events

### API Updates (\http.ts\)
- Removed \webhookUrl\ from registration payload type
- Updated \
otificationMethod\ to only accept \websocket | polling\
- Added \limit\ and \cursor\ query params to GET \/api/notifications\

### Tests (\
otifications.test.ts\)
- Updated existing tests for new return format (\esult.notifications\ instead of \
otifications\)
- Added new test for cursor-based pagination

## API Changes

| Endpoint | Change |
|----------|--------|
| \POST /api/agents/register\ | \webhookUrl\ removed, \
otificationMethod\ only accepts \websocket\ or \polling\ |
| \GET /api/notifications\ | Now supports \?cursor=<timestamp>&limit=<n>\ for efficient polling |

## Benefits
1. **Real-time when possible** — WebSocket for responsive agents
2. **Reliable fallback** — Polling works everywhere
3. **No open ports** — Both methods are outbound connections from agent
4. **Simpler than webhooks** — No retry logic, no delivery failures

Closes #3