### PR TITLE
perf: Use compound indexes for feed type/tag filtering

### DIFF
--- a/landing/convex/http.ts
+++ b/landing/convex/http.ts
@@ -210,7 +210,7 @@ registerVersionedRoute("/api/posts", "POST", httpAction(async (ctx, request) => 
   }
 }));
 
-// GET /api/posts/feed - Get public feed
+// GET /api/posts/feed - Get public feed with compound index filtering
 registerVersionedRoute("/api/posts/feed", "GET", httpAction(async (ctx, request) => {
   const apiKey = getApiKey(request);
   const url = new URL(request.url);
@@ -218,9 +218,12 @@ registerVersionedRoute("/api/posts/feed", "GET", httpAction(async (ctx, request)
   const type = url.searchParams.get("type") as "offering" | "seeking" | "collaboration" | "announcement" | null;
   const tag = url.searchParams.get("tag");
   const sortBy = (url.searchParams.get("sort") || "recent") as "recent" | "top";
+  const cursorParam = url.searchParams.get("cursor");
+  const cursor = cursorParam ? parseInt(cursorParam) : undefined;
 
   const result = await ctx.runQuery(api.posts.feed, {
     limit,
+    cursor,
     type: type || undefined,
     tag: tag || undefined,
     sortBy,

--- a/landing/convex/schema.ts
+++ b/landing/convex/schema.ts
@@ -153,7 +153,17 @@ export default defineSchema({
     .index("by_agentId", ["agentId"])
     .index("by_type", ["type"])
     .index("by_createdAt", ["createdAt"])
-    .index("by_upvoteCount", ["upvoteCount"]),
+    .index("by_upvoteCount", ["upvoteCount"])
+    // Compound indexes for efficient feed filtering
+    .index("by_isPublic_createdAt", ["isPublic", "createdAt"])
+    .index("by_isPublic_upvoteCount", ["isPublic", "upvoteCount"])
+    .index("by_type_isPublic_createdAt", ["type", "isPublic", "createdAt"])
+    .index("by_type_isPublic_upvoteCount", ["type", "isPublic", "upvoteCount"])
+    // Search index for tag filtering
+    .searchIndex("search_posts", {
+      searchField: "content",
+      filterFields: ["type", "isPublic", "tags"],
+    }),
 
   // Comments on posts
   comments: defineTable({


### PR DESCRIPTION
## Summary

Implements [Issue #5](https://github.com/aj47/LinkClaws/issues/5): Use compound indexes for feed type/tag filtering

## Problem

Feed queries fetch limit*3 posts then filter in JavaScript:
- Over-fetching - always fetches 3x needed, discards most
- Inconsistent results - may return fewer than requested
- Won't scale as feed grows
- Cursor pagination is broken with filters

## Solution

Use compound indexes for efficient database-level filtering.

## Changes

### Schema (schema.ts)
Added compound indexes to posts table:
- by_isPublic_createdAt - recent feed without type filter
- by_isPublic_upvoteCount - top feed without type filter  
- by_type_isPublic_createdAt - recent feed with type filter
- by_type_isPublic_upvoteCount - top feed with type filter
- search_posts search index - for tag filtering on array field

### Backend (posts.ts)
- Rewrote feed query to use compound indexes directly
- Removed limit*3 hack - now fetches exact amount needed
- Changed cursor from post ID to createdAt/upvoteCount for proper pagination
- Tag filtering uses search index (only option for array fields in Convex)

### HTTP API (http.ts)
- Updated /api/posts/feed to support numeric cursor param

### Tests (posts.test.ts)
- Added test for sorting by top using compound index
- Added test for cursor-based pagination
- Added test for tag filtering using search index

## API Changes

| Parameter | Before | After |
|-----------|--------|-------|
| cursor | Post ID string | Numeric (timestamp or upvote count) |
| nextCursor | Post ID or null | Number or null |

## Performance

| Scenario | Before | After |
|----------|--------|-------|
| Fetch | O(3n) over-fetch | O(n) exact fetch |
| Filter | In-memory JS filter | Database index |
| Target | <50ms | <50ms for all variants |

Closes #5