### PR TITLE
feat: Add API key rotation mechanism

### DIFF
--- a/landing/convex/agents.test.ts
+++ b/landing/convex/agents.test.ts
@@ -157,5 +157,214 @@ describe("agents", () => {
       expect(agent).toBeNull();
     });
   });
+
+  describe("API key management", () => {
+    test("should create a new API key", async () => {
+      const t = convexTest(schema, modules);
+
+      // Create agent
+      const inviteCodes = await t.mutation(api.invites.createFoundingInvite, {
+        adminSecret: "linkclaws-admin-2024",
+        count: 1,
+      });
+      const regResult = await t.mutation(api.agents.register, {
+        inviteCode: inviteCodes[0],
+        name: "Key Test Agent",
+        handle: "keytestagent",
+        entityName: "Test Company",
+        capabilities: [],
+        interests: [],
+        autonomyLevel: "full_autonomy",
+        notificationMethod: "polling",
+      });
+
+      if (!regResult.success) throw new Error("Failed to create agent");
+
+      // Create a new API key
+      const createResult = await t.mutation(api.agents.createApiKey, {
+        apiKey: regResult.apiKey,
+        name: "production",
+      });
+
+      expect(createResult.success).toBe(true);
+      if (createResult.success) {
+        expect(createResult.apiKey).toMatch(/^lc_/);
+        expect(createResult.keyPrefix).toMatch(/^lc_/);
+        expect(createResult.keyId).toBeDefined();
+      }
+    });
+
+    test("should list API keys", async () => {
+      const t = convexTest(schema, modules);
+
+      // Create agent
+      const inviteCodes = await t.mutation(api.invites.createFoundingInvite, {
+        adminSecret: "linkclaws-admin-2024",
+        count: 1,
+      });
+      const regResult = await t.mutation(api.agents.register, {
+        inviteCode: inviteCodes[0],
+        name: "List Keys Agent",
+        handle: "listkeysagent",
+        entityName: "Test Company",
+        capabilities: [],
+        interests: [],
+        autonomyLevel: "full_autonomy",
+        notificationMethod: "polling",
+      });
+
+      if (!regResult.success) throw new Error("Failed to create agent");
+
+      // Create two API keys
+      await t.mutation(api.agents.createApiKey, {
+        apiKey: regResult.apiKey,
+        name: "key1",
+      });
+      await t.mutation(api.agents.createApiKey, {
+        apiKey: regResult.apiKey,
+        name: "key2",
+      });
+
+      // List keys
+      const keys = await t.query(api.agents.listApiKeys, {
+        apiKey: regResult.apiKey,
+      });
+
+      expect(keys.length).toBe(2);
+      expect(keys.every(k => k.isActive)).toBe(true);
+      expect(keys.some(k => k.name === "key1")).toBe(true);
+      expect(keys.some(k => k.name === "key2")).toBe(true);
+    });
+
+    test("should revoke an API key", async () => {
+      const t = convexTest(schema, modules);
+
+      // Create agent
+      const inviteCodes = await t.mutation(api.invites.createFoundingInvite, {
+        adminSecret: "linkclaws-admin-2024",
+        count: 1,
+      });
+      const regResult = await t.mutation(api.agents.register, {
+        inviteCode: inviteCodes[0],
+        name: "Revoke Key Agent",
+        handle: "revokekeyagent",
+        entityName: "Test Company",
+        capabilities: [],
+        interests: [],
+        autonomyLevel: "full_autonomy",
+        notificationMethod: "polling",
+      });
+
+      if (!regResult.success) throw new Error("Failed to create agent");
+
+      // Create a new key
+      const createResult = await t.mutation(api.agents.createApiKey, {
+        apiKey: regResult.apiKey,
+        name: "to-revoke",
+      });
+
+      if (!createResult.success) throw new Error("Failed to create key");
+
+      // Revoke the new key using the original key
+      const revokeResult = await t.mutation(api.agents.revokeApiKey, {
+        apiKey: regResult.apiKey,
+        keyId: createResult.keyId,
+        reason: "Testing revocation",
+      });
+
+      expect(revokeResult.success).toBe(true);
+
+      // Verify key is revoked
+      const keys = await t.query(api.agents.listApiKeys, {
+        apiKey: regResult.apiKey,
+      });
+      const revokedKey = keys.find(k => k._id === createResult.keyId);
+      expect(revokedKey?.isActive).toBe(false);
+      expect(revokedKey?.revokedReason).toBe("Testing revocation");
+    });
+
+    test("should not allow revoking the current auth key", async () => {
+      const t = convexTest(schema, modules);
+
+      // Create agent
+      const inviteCodes = await t.mutation(api.invites.createFoundingInvite, {
+        adminSecret: "linkclaws-admin-2024",
+        count: 1,
+      });
+      const regResult = await t.mutation(api.agents.register, {
+        inviteCode: inviteCodes[0],
+        name: "Self Revoke Agent",
+        handle: "selfrevokeagent",
+        entityName: "Test Company",
+        capabilities: [],
+        interests: [],
+        autonomyLevel: "full_autonomy",
+        notificationMethod: "polling",
+      });
+
+      if (!regResult.success) throw new Error("Failed to create agent");
+
+      // Create a new key and use it
+      const createResult = await t.mutation(api.agents.createApiKey, {
+        apiKey: regResult.apiKey,
+        name: "new-key",
+      });
+
+      if (!createResult.success) throw new Error("Failed to create key");
+
+      // Try to revoke the key we're using for auth
+      const revokeResult = await t.mutation(api.agents.revokeApiKey, {
+        apiKey: createResult.apiKey,
+        keyId: createResult.keyId,
+      });
+
+      expect(revokeResult.success).toBe(false);
+      if (!revokeResult.success) {
+        expect(revokeResult.error).toContain("currently using");
+      }
+    });
+
+    test("should enforce maximum 5 active keys", async () => {
+      const t = convexTest(schema, modules);
+
+      // Create agent
+      const inviteCodes = await t.mutation(api.invites.createFoundingInvite, {
+        adminSecret: "linkclaws-admin-2024",
+        count: 1,
+      });
+      const regResult = await t.mutation(api.agents.register, {
+        inviteCode: inviteCodes[0],
+        name: "Max Keys Agent",
+        handle: "maxkeysagent",
+        entityName: "Test Company",
+        capabilities: [],
+        interests: [],
+        autonomyLevel: "full_autonomy",
+        notificationMethod: "polling",
+      });
+
+      if (!regResult.success) throw new Error("Failed to create agent");
+
+      // Create 5 keys (max allowed)
+      for (let i = 0; i < 5; i++) {
+        const result = await t.mutation(api.agents.createApiKey, {
+          apiKey: regResult.apiKey,
+          name: `key${i}`,
+        });
+        expect(result.success).toBe(true);
+      }
+
+      // Try to create a 6th key
+      const sixthResult = await t.mutation(api.agents.createApiKey, {
+        apiKey: regResult.apiKey,
+        name: "key6",
+      });
+
+      expect(sixthResult.success).toBe(false);
+      if (!sixthResult.success) {
+        expect(sixthResult.error).toContain("Maximum 5");
+      }
+    });
+  });
 });
 

--- a/landing/convex/agents.ts
+++ b/landing/convex/agents.ts
@@ -556,3 +556,236 @@ export const updateLastActive = mutation({
   },
 });
 
+// ============ API KEY MANAGEMENT ============
+
+// API key response type (never expose full key or hash)
+const apiKeyInfoType = v.object({
+  _id: v.id("agentApiKeys"),
+  keyPrefix: v.string(),
+  name: v.optional(v.string()),
+  createdAt: v.number(),
+  lastUsedAt: v.optional(v.number()),
+  revokedAt: v.optional(v.number()),
+  revokedReason: v.optional(v.string()),
+  isActive: v.boolean(),
+});
+
+// Create a new API key (rotate)
+export const createApiKey = mutation({
+  args: {
+    apiKey: v.string(), // Current valid API key for auth
+    name: v.optional(v.string()), // Optional name like "production", "staging"
+  },
+  returns: v.union(
+    v.object({
+      success: v.literal(true),
+      apiKey: v.string(), // The new API key (only shown once)
+      keyId: v.id("agentApiKeys"),
+      keyPrefix: v.string(),
+    }),
+    v.object({
+      success: v.literal(false),
+      error: v.string(),
+    })
+  ),
+  handler: async (ctx, args) => {
+    const agentId = await verifyApiKey(ctx, args.apiKey);
+    if (!agentId) {
+      return { success: false as const, error: "Invalid API key" };
+    }
+
+    // Check how many active keys the agent has (limit to 5)
+    const existingKeys = await ctx.db
+      .query("agentApiKeys")
+      .withIndex("by_agentId", (q) => q.eq("agentId", agentId))
+      .collect();
+    
+    const activeKeys = existingKeys.filter(k => !k.revokedAt);
+    if (activeKeys.length >= 5) {
+      return { 
+        success: false as const, 
+        error: "Maximum 5 active API keys allowed. Revoke an existing key first." 
+      };
+    }
+
+    // Generate new key
+    const newApiKey = generateApiKey();
+    const keyHash = await hashApiKey(newApiKey);
+    const keyPrefix = newApiKey.substring(0, 11);
+    const now = Date.now();
+
+    const keyId = await ctx.db.insert("agentApiKeys", {
+      agentId,
+      keyHash,
+      keyPrefix,
+      name: args.name,
+      createdAt: now,
+    });
+
+    // Log activity
+    await ctx.db.insert("activityLog", {
+      agentId,
+      action: "api_key_created",
+      description: `New API key created${args.name ? ` (${args.name})` : ""}`,
+      requiresApproval: false,
+      createdAt: now,
+    });
+
+    return {
+      success: true as const,
+      apiKey: newApiKey, // Only time the full key is returned
+      keyId,
+      keyPrefix,
+    };
+  },
+});
+
+// List all API keys for the agent (prefixes only, never full keys)
+export const listApiKeys = query({
+  args: {
+    apiKey: v.string(),
+  },
+  returns: v.array(apiKeyInfoType),
+  handler: async (ctx, args) => {
+    const agentId = await verifyApiKey(ctx, args.apiKey);
+    if (!agentId) return [];
+
+    const keys = await ctx.db
+      .query("agentApiKeys")
+      .withIndex("by_agentId", (q) => q.eq("agentId", agentId))
+      .collect();
+
+    return keys.map(k => ({
+      _id: k._id,
+      keyPrefix: k.keyPrefix,
+      name: k.name,
+      createdAt: k.createdAt,
+      lastUsedAt: k.lastUsedAt,
+      revokedAt: k.revokedAt,
+      revokedReason: k.revokedReason,
+      isActive: !k.revokedAt,
+    }));
+  },
+});
+
+// Revoke an API key
+export const revokeApiKey = mutation({
+  args: {
+    apiKey: v.string(), // Current valid API key for auth
+    keyId: v.id("agentApiKeys"), // The key to revoke
+    reason: v.optional(v.string()), // Optional reason for revocation
+  },
+  returns: v.union(
+    v.object({ success: v.literal(true) }),
+    v.object({ success: v.literal(false), error: v.string() })
+  ),
+  handler: async (ctx, args) => {
+    const agentId = await verifyApiKey(ctx, args.apiKey);
+    if (!agentId) {
+      return { success: false as const, error: "Invalid API key" };
+    }
+
+    const keyToRevoke = await ctx.db.get(args.keyId);
+    if (!keyToRevoke) {
+      return { success: false as const, error: "API key not found" };
+    }
+
+    // Verify ownership
+    if (keyToRevoke.agentId !== agentId) {
+      return { success: false as const, error: "Not authorized to revoke this key" };
+    }
+
+    // Check if already revoked
+    if (keyToRevoke.revokedAt) {
+      return { success: false as const, error: "API key already revoked" };
+    }
+
+    // Check if this is the key being used for auth (can't revoke yourself)
+    const authKeyPrefix = args.apiKey.substring(0, 11);
+    if (keyToRevoke.keyPrefix === authKeyPrefix) {
+      return { success: false as const, error: "Cannot revoke the key you're currently using" };
+    }
+
+    const now = Date.now();
+
+    await ctx.db.patch(args.keyId, {
+      revokedAt: now,
+      revokedReason: args.reason,
+    });
+
+    // Log activity
+    await ctx.db.insert("activityLog", {
+      agentId,
+      action: "api_key_revoked",
+      description: `API key revoked${args.reason ? `: ${args.reason}` : ""}`,
+      requiresApproval: false,
+      createdAt: now,
+    });
+
+    return { success: true as const };
+  },
+});
+
+// Migrate legacy key to agentApiKeys table
+export const migrateLegacyKey = mutation({
+  args: {
+    apiKey: v.string(), // The legacy API key to migrate
+    name: v.optional(v.string()), // Optional name for the migrated key
+  },
+  returns: v.union(
+    v.object({ success: v.literal(true), keyId: v.id("agentApiKeys") }),
+    v.object({ success: v.literal(false), error: v.string() })
+  ),
+  handler: async (ctx, args) => {
+    if (!args.apiKey || !args.apiKey.startsWith("lc_")) {
+      return { success: false as const, error: "Invalid API key format" };
+    }
+
+    const prefix = args.apiKey.substring(0, 11);
+    const hashedKey = await hashApiKey(args.apiKey);
+
+    // Check if this is a legacy key on the agents table
+    const agent = await ctx.db
+      .query("agents")
+      .withIndex("by_apiKeyPrefix", (q) => q.eq("apiKeyPrefix", prefix))
+      .first();
+
+    if (!agent || agent.apiKey !== hashedKey) {
+      return { success: false as const, error: "Invalid API key" };
+    }
+
+    // Check if already migrated
+    const existingMigration = await ctx.db
+      .query("agentApiKeys")
+      .withIndex("by_keyPrefix", (q) => q.eq("keyPrefix", prefix))
+      .first();
+
+    if (existingMigration) {
+      return { success: false as const, error: "Key already migrated" };
+    }
+
+    const now = Date.now();
+
+    // Create entry in agentApiKeys
+    const keyId = await ctx.db.insert("agentApiKeys", {
+      agentId: agent._id,
+      keyHash: hashedKey,
+      keyPrefix: prefix,
+      name: args.name ?? "legacy",
+      createdAt: agent.createdAt, // Use original creation time
+      lastUsedAt: now,
+    });
+
+    // Log activity
+    await ctx.db.insert("activityLog", {
+      agentId: agent._id,
+      action: "api_key_migrated",
+      description: "Legacy API key migrated to new key management system",
+      requiresApproval: false,
+      createdAt: now,
+    });
+
+    return { success: true as const, keyId };
+  },
+});
+

--- a/landing/convex/http.ts
+++ b/landing/convex/http.ts
@@ -166,6 +166,73 @@ registerVersionedRoute("/api/agents/by-handle", "GET", httpAction(async (ctx, re
   return jsonResponse(result);
 }));
 
+// ============ API KEY MANAGEMENT ============
+
+// POST /api/agents/keys/create - Create a new API key (rotate)
+registerVersionedRoute("/api/agents/keys/create", "POST", httpAction(async (ctx, request) => {
+  const apiKey = getApiKey(request);
+  if (!apiKey) {
+    return jsonResponse({ error: "API key required" }, 401);
+  }
+  try {
+    const body = await request.json() as { name?: string };
+    const result = await ctx.runMutation(api.agents.createApiKey, {
+      apiKey,
+      name: body.name,
+    });
+    return jsonResponse(result, result.success ? 201 : 400);
+  } catch (error) {
+    return jsonResponse({ success: false, error: String(error) }, 400);
+  }
+}));
+
+// GET /api/agents/keys - List all API keys (prefixes only)
+registerVersionedRoute("/api/agents/keys", "GET", httpAction(async (ctx, request) => {
+  const apiKey = getApiKey(request);
+  if (!apiKey) {
+    return jsonResponse({ error: "API key required" }, 401);
+  }
+  const result = await ctx.runQuery(api.agents.listApiKeys, { apiKey });
+  return jsonResponse(result);
+}));
+
+// DELETE /api/agents/keys/revoke - Revoke an API key
+registerVersionedRoute("/api/agents/keys/revoke", "POST", httpAction(async (ctx, request) => {
+  const apiKey = getApiKey(request);
+  if (!apiKey) {
+    return jsonResponse({ error: "API key required" }, 401);
+  }
+  try {
+    const body = await request.json() as { keyId: string; reason?: string };
+    const result = await ctx.runMutation(api.agents.revokeApiKey, {
+      apiKey,
+      keyId: body.keyId as any,
+      reason: body.reason,
+    });
+    return jsonResponse(result, result.success ? 200 : 400);
+  } catch (error) {
+    return jsonResponse({ success: false, error: String(error) }, 400);
+  }
+}));
+
+// POST /api/agents/keys/migrate - Migrate legacy key to new system
+registerVersionedRoute("/api/agents/keys/migrate", "POST", httpAction(async (ctx, request) => {
+  const apiKey = getApiKey(request);
+  if (!apiKey) {
+    return jsonResponse({ error: "API key required" }, 401);
+  }
+  try {
+    const body = await request.json() as { name?: string };
+    const result = await ctx.runMutation(api.agents.migrateLegacyKey, {
+      apiKey,
+      name: body.name,
+    });
+    return jsonResponse(result, result.success ? 200 : 400);
+  } catch (error) {
+    return jsonResponse({ success: false, error: String(error) }, 400);
+  }
+}));
+
 // GET /api/agents - List agents
 registerVersionedRoute("/api/agents", "GET", httpAction(async (ctx, request) => {
   const url = new URL(request.url);
@@ -562,6 +629,10 @@ registerVersionedCors("/api/agents/me");
 registerVersionedCors("/api/agents/by-handle");
 registerVersionedCors("/api/agents");
 registerVersionedCors("/api/agents/search");
+registerVersionedCors("/api/agents/keys");
+registerVersionedCors("/api/agents/keys/create");
+registerVersionedCors("/api/agents/keys/revoke");
+registerVersionedCors("/api/agents/keys/migrate");
 registerVersionedCors("/api/posts");
 registerVersionedCors("/api/posts/feed");
 registerVersionedCors("/api/posts/by-id");

--- a/landing/convex/schema.ts
+++ b/landing/convex/schema.ts
@@ -244,6 +244,20 @@ export default defineSchema({
     .index("by_createdByAgentId", ["createdByAgentId"])
     .index("by_usedByAgentId", ["usedByAgentId"]),
 
+  // API Keys - supports multiple keys per agent with rotation
+  agentApiKeys: defineTable({
+    agentId: v.id("agents"),
+    keyHash: v.string(),
+    keyPrefix: v.string(), // "lc_" + first 8 chars for identification
+    name: v.optional(v.string()), // e.g., "production", "staging", "development"
+    createdAt: v.number(),
+    lastUsedAt: v.optional(v.number()),
+    revokedAt: v.optional(v.number()),
+    revokedReason: v.optional(v.string()),
+  })
+    .index("by_agentId", ["agentId"])
+    .index("by_keyPrefix", ["keyPrefix"]),
+
   // Notifications
   notifications: defineTable({
     agentId: v.id("agents"), // recipient


### PR DESCRIPTION
## Summary

Implements [Issue #7](https://github.com/aj47/LinkClaws/issues/7): Add API key rotation mechanism

## Problem

Agents have exactly one API key forever:
- No rotation if key is compromised
- No revocation without deleting the agent
- No audit trail for key usage

## Solution

Support multiple API keys with rotation, revocation, and audit tracking.

## Changes

### Schema (schema.ts)
Added agentApiKeys table:
- agentId, keyHash, keyPrefix
- name (e.g., production, staging)
- createdAt, lastUsedAt
- revokedAt, revokedReason

### Utils (lib/utils.ts)
- verifyApiKey checks agentApiKeys table first, then fallback to legacy key
- getAgentByApiKey updates lastUsedAt on each use

### Backend (agents.ts)
- createApiKey - generate new key (max 5 active per agent)
- listApiKeys - returns metadata only (prefixes, never full keys)
- revokeApiKey - soft delete with reason, prevents self-revocation
- migrateLegacyKey - migrate legacy key to new system

### HTTP API (http.ts)
- POST /api/agents/keys/create - Create new API key
- GET /api/agents/keys - List all keys (prefixes only)
- POST /api/agents/keys/revoke - Revoke a key
- POST /api/agents/keys/migrate - Migrate legacy key

### Tests (agents.test.ts)
- Create new API key
- List API keys
- Revoke API key with reason
- Prevent self-revocation
- Enforce max 5 active keys

## Security Features

| Feature | Implementation |
|---------|---------------|
| Multiple keys | Up to 5 active keys per agent |
| Revocation | Soft delete with reason tracking |
| Audit trail | lastUsedAt updated on each use |
| Self-protection | Cannot revoke key used for auth |
| Legacy support | Backward compatible with existing keys |
| Storage | SHA-256 hashed, never stored in plain text |

## Migration Path

1. Existing agents keep working with legacy key
2. Call /api/agents/keys/migrate to add legacy key to new system
3. Create new keys as needed
4. Revoke old keys when ready

Closes #7