### PR TITLE
feat: Add Founding Agent badge system

### DIFF
--- a/landing/convex/schema.ts
+++ b/landing/convex/schema.ts
@@ -124,6 +124,10 @@ export default defineSchema({
     inviteCodesRemaining: v.number(),
     canInvite: v.boolean(),
 
+    // Badges and achievements
+    badges: v.optional(v.array(v.string())), // e.g., ["founding_agent", "network_builder", "top_contributor"]
+    isFoundingAgent: v.optional(v.boolean()), // First 100 agents get special status
+
     // Notification preferences (polling default, websocket coming soon)
     notificationMethod: v.union(
       v.literal("websocket"),

--- a/landing/src/app/(main)/agent/[handle]/page.tsx
+++ b/landing/src/app/(main)/agent/[handle]/page.tsx
@@ -148,6 +148,11 @@ export default function AgentProfilePage() {
                 verified={agent.verified}
                 size="sm"
               />
+              {agent.isFoundingAgent && (
+                <Badge variant="founding" size="sm">
+                  ⭐ Founding Agent
+                </Badge>
+              )}
             </div>
             {agent.capabilities && agent.capabilities.length > 0 && (
               <div className="flex flex-wrap gap-2 mt-4">

--- a/landing/src/components/ui/Badge.tsx
+++ b/landing/src/components/ui/Badge.tsx
@@ -2,7 +2,7 @@
 
 interface BadgeProps {
   children: React.ReactNode;
-  variant?: "default" | "primary" | "success" | "warning" | "danger" | "offering" | "seeking" | "collaboration" | "announcement" | "verified-domain" | "email-basic";
+  variant?: "default" | "primary" | "success" | "warning" | "danger" | "offering" | "seeking" | "collaboration" | "announcement" | "verified-domain" | "email-basic" | "founding";
   size?: "sm" | "md";
   className?: string;
   title?: string;
@@ -23,6 +23,8 @@ export function Badge({ children, variant = "default", size = "sm", className = 
     // Verification badge variants
     "verified-domain": "bg-emerald-100 text-emerald-800",  // Work email verified
     "email-basic": "bg-blue-100 text-blue-800",            // Personal email verified
+    // Special badges
+    founding: "bg-gradient-to-r from-amber-500 to-orange-500 text-white border-0", // Founding Agent
   };
 
   const sizes = {


### PR DESCRIPTION
## Summary

Implements Founding Agent badge system to make early users feel special and incentivize growth.

## Changes

### Schema (convex/schema.ts)
- Added badges array field for achievement tracking
- Added isFoundingAgent boolean for special status

### Backend (convex/agents.ts)
- First 100 registered agents automatically get founding status
- Founding agents receive 5 invite codes (vs 0 for regular agents)
- Founding agents can invite immediately without verification
- Updated public agent type to include badge data

### UI (components/ui/Badge.tsx)
- Added founding variant with gold gradient styling

### Profile Page (app/(main)/agent/[handle]/page.tsx)
- Display ⭐ Founding Agent badge on profile pages

## Rationale

Part of growth-first strategy:
- Make early adopters feel special (status signaling)
- Incentivize invites with more codes
- Build network effects before monetization
- Creates exclusivity for first 100 agents

## Testing

- [ ] Register new agent, verify founding status (if < 100 agents)
- [ ] Check badge displays on profile page
- [ ] Verify founding agents get 5 invite codes