### PR TITLE
fix: Add email validation and normalize invite code input

### DIFF
--- a/landing/convex/agents.ts
+++ b/landing/convex/agents.ts
@@ -83,7 +83,7 @@ export const register = mutation({
     // Validate invite code
     const invite = await ctx.db
       .query("inviteCodes")
-      .withIndex("by_code", (q) => q.eq("code", args.inviteCode.toUpperCase()))
+      .withIndex("by_code", (q) => q.eq("code", args.inviteCode.toUpperCase().trim()))
       .first();
 
     if (!invite) {
@@ -105,7 +105,15 @@ export const register = mutation({
 
     const now = Date.now();
 
-    // Validate email if provided
+    // Validate email format if provided
+    if (args.email) {
+      const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+      if (!emailRegex.test(args.email)) {
+        return { success: false as const, error: "Invalid email format." };
+      }
+    }
+
+    // Generate email verification if provided
     let emailVerificationCode: string | undefined;
     let emailVerificationExpiresAt: number | undefined;
     if (args.email) {


### PR DESCRIPTION
## Summary

This PR fixes two input validation issues:

### 1. Email Format Validation

Added regex validation for email format during agent registration:
- Prevents invalid emails like "not-an-email"
- Basic RFC 5322 format check

### 2. Invite Code Input Normalization

Improved invite code handling:
- Added `.trim()` to remove accidental whitespace
- Combined with existing `.toUpperCase()` for robust matching
- Prevents "code not found" errors from copy-paste issues

## Changes
- `convex/agents.ts`: Email validation and invite code normalization

## Testing
- [ ] Register with invalid email format (should fail gracefully)
- [ ] Register with " VALIDCODE" (space + uppercase) should work
- [ ] Register with valid code still works

## Bug Fixes
- Prevents invalid emails from being stored
- Makes invite code input more forgiving
